### PR TITLE
Bump osrm-deps version to 2017.09

### DIFF
--- a/scripts/build_osrm.bat
+++ b/scripts/build_osrm.bat
@@ -38,7 +38,9 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 SET ARCH=x64
 if %TARGET_ARCH% EQU 32 SET ARCH=x86
 
-SET PKGNAME=osrm-deps-win-%TOOLS_VERSION%-%ARCH%.7z
+for /f %%i in ('powershell Get-Date -format "yyyy.MM"') do set DATE_VERSION=%%i
+
+SET PKGNAME=osrm-deps-win-%ARCH%-%TOOLS_VERSION%-%DATE_VERSION%.7z
 
 CD %PKGDIR%\osrm-deps
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/build_osrm_deps.bat
+++ b/scripts/build_osrm_deps.bat
@@ -46,7 +46,9 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 SET ARCH=x64
 if %TARGET_ARCH% EQU 32 SET ARCH=x86
 
-SET PKGNAME=osrm-deps-win-%ARCH%-%TOOLS_VERSION%.7z
+for /f %%i in ('powershell Get-Date -format "yyyy.MM"') do set DATE_VERSION=%%i
+
+SET PKGNAME=osrm-deps-win-%ARCH%-%TOOLS_VERSION%-%DATE_VERSION%.7z
 
 cd %PKGDIR%\osrm-deps
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/build_tbb.bat
+++ b/scripts/build_tbb.bat
@@ -8,20 +8,22 @@ IF "%ROOTDIR%"=="" ( echo "ROOTDIR variable not set" && GOTO ERROR )
 cd %PKGDIR%
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-CALL %ROOTDIR%\scripts\download tbb%TBB_VERSION%_src.tgz
+CALL %ROOTDIR%\scripts\download https://github.com/01org/tbb/archive/2018_U1.tar.gz
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+powershell "if (!$(Get-FileHash 2018_U1.tar.gz -Algorithm SHA1 | Select-String F0692F6E5665E5069D70813532B0DF34FCE7CF4D)) { Write-Error 'SHA1 mismatch' -Category InvalidData ; exit 1 }"
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 if EXIST tbb ECHO found extracted sources && GOTO SRCFOUND
 
 ECHO extracting
-CALL bsdtar xfz tbb%TBB_VERSION%_src.tgz
-RENAME tbb%TBB_VERSION% tbb
+CALL bsdtar xfz 2018_U1.tar.gz
+RENAME tbb-2018_U1 tbb
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 
 :SRCFOUND
 
-cd %PKGDIR%\tbb\build\vs2010
+cd %PKGDIR%\tbb\build\vs2013
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 

--- a/scripts/package_osrm_deps.ps1
+++ b/scripts/package_osrm_deps.ps1
@@ -27,7 +27,7 @@ $boost_include_src_dir = "$env:PKGDIR\boost\boost\"
 $boost_include_dest_dir = "${osrm_deps_dir}boost\include\boost-1_$env:BOOST_VERSION\"
 
 #tbb
-$tbb_lib_src_dir = "$env:PKGDIR\tbb\lib\v140\intel64\Release\"
+$tbb_lib_src_dir = "$env:PKGDIR\tbb\lib\v140\x64\Release\"
 $tbb_include_src_dir = "$env:PKGDIR\tbb\include\"
 
 #delete existing deps dir
@@ -63,7 +63,7 @@ $file_list = @{
         ("$env:PKGDIR" + "\expat\lib\expat_external.h"),
         ("$env:PKGDIR" + "\lua\src\lauxlib.h"),
         ("$env:PKGDIR" + "\lua\src\lua.h"),
-        ("$env:PKGDIR" + "\lua\etc\lua.hpp"),
+        ("$env:PKGDIR" + "\lua\src\lua.hpp"),
         ("$env:PKGDIR" + "\lua\src\luaconf.h"),
         ("$env:PKGDIR" + "\lua\src\lualib.h"),
         ("$env:PKGDIR" + "\stxxl\include\stxxl.h"),


### PR DESCRIPTION
For https://github.com/Project-OSRM/osrm-backend/issues/4534 i added `DATE_VERSION` to `PKGNAME=osrm-deps-win-%ARCH%-%TOOLS_VERSION%-%DATE_VERSION%.7z` otherwise it is not possible to keep back-compatible building for OSRM.

Reverted `osrm-deps-win-x64-14.0.7z` on S3 and uploaded a new file `osrm-deps-win-x64-14.0-2017.09.7z`
The new file includes updates:
* boost 1.63
* TBB 2018_U1
* liblua 5.2